### PR TITLE
Fix faulty install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.1",
   "description": "Micro library to create actions for redux with automatically inferred TypeScript types",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": ["dist/"],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "redux-dry-ts-actions",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Micro library to create actions for redux with automatically inferred TypeScript types",
   "main": "dist/index.js",
+  "files": ["dist/"],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "install": "tsc"
+    "prepublish": "npm run build",
+    "build": "tsc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-dry-ts-actions",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Micro library to create actions for redux with automatically inferred TypeScript types",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
In the current setup, the package would want to run `tsc` upon being installed. This will fail the installer if there's no `tsc` available - for example in sandboxed environments.

It's also a good practise, to distribute the built code, rather than the source and build it when the user installs the package.

In this PR:
- I removed the `install` script to prevent building.
- Added a `prepublish` build step (this will prepare the distributable versions of the code)
- Marked the `dist/` folder in the `files` section, so only these files get in the tarfile when published, and when downloaded

Tested it locally with `npm pack` and inspecting the tar file's content - looks OK. Will need you to publish a new version however.